### PR TITLE
Fix narrations in create_sentence_df()

### DIFF
--- a/src/scripts/create_feature_files.py
+++ b/src/scripts/create_feature_files.py
@@ -42,8 +42,8 @@ def create_sentence_df(df):
     missing_classes = set(df.action_class.unique()) - set(classes.values())
     i = len(indices)
     for class_ in missing_classes:
-        sentences[i] = subset_df.iloc[0].narration
         subset_df = df[df.action_class.apply(lambda x: x == class_)]
+        sentences[i] = subset_df.iloc[0].narration
         indices[i] = subset_df.index[0]
         classes[i] = subset_df.iloc[0].action_class
         verb_class[i] = subset_df.iloc[0].verb_class

--- a/src/scripts/create_sentence_df.py
+++ b/src/scripts/create_sentence_df.py
@@ -33,8 +33,8 @@ def create_sentence_df(df):
     missing_classes = set(df.action_class.unique()) - set(classes.values())
     i = len(indices)
     for class_ in missing_classes:
-        sentences[i] = subset_df.iloc[0].narration
         subset_df = df[df.action_class.apply(lambda x: x == class_)]
+        sentences[i] = subset_df.iloc[0].narration
         indices[i] = subset_df.index[0]
         classes[i] = subset_df.iloc[0].action_class
         verb_class[i] = subset_df.iloc[0].verb_class


### PR DESCRIPTION
`sentence` value for each `missing_classes` is wrongly set as the narration of the **previous** `subset_df`.

Accordingly, the sentence files provided in https://github.com/mwray/Joint-Part-of-Speech-Embeddings#data have some bugs.